### PR TITLE
Create notify-parent.js (for deep-linking of MKdocs in WordPress site)

### DIFF
--- a/docs/wordpress-site/notify-parent.js
+++ b/docs/wordpress-site/notify-parent.js
@@ -1,0 +1,22 @@
+(function () {
+  function notifyParent() {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage(
+        {
+          type: 'mkdocs-url-change',
+          url: window.location.href
+        },
+        'https://unbiodiversitylab.org'
+      );
+    }
+  }
+
+  notifyParent();
+
+  window.addEventListener('popstate', notifyParent);
+  window.addEventListener('hashchange', notifyParent);
+
+  document.addEventListener('click', function () {
+    setTimeout(notifyParent, 300);
+  });
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -414,6 +414,7 @@ extra_css:
 extra_javascript:
   - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+  - wordpress-site/notify-parent.js
 
 # Extra Configuration
 extra:


### PR DESCRIPTION
1. Adds a JavaScript helper to notify the parent WordPress site about MKDocs navigation changes inside the iframe, enabling shareable deep links to specific documentation sections.

2. Adds [- wordpress-site/notify-parent.js] under [extra_javascript:] in mkdocs.yml.